### PR TITLE
docs: normalize structure paths to pretty URLs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -91,36 +91,36 @@ github:
 structure:
   introduction:
     - title: "まえがき"
-      path: "/src/introduction/preface.html"
+      path: "/src/introduction/preface/"
   
   chapters:
     - id: 1
       title: "エンジニアの思考OS"
-      path: "/src/chapter-1/index.html"
+      path: "/src/chapter-1/index/"
     - id: 2
       title: "要件定義の認知プロセス"
-      path: "/src/chapter-2/index.html"
+      path: "/src/chapter-2/index/"
     - id: 3
       title: "アーキテクチャ設計の意思決定"
-      path: "/src/chapter-3/index.html"
+      path: "/src/chapter-3/index/"
     - id: 4
       title: "開発/構築フェーズの最適化思考"
-      path: "/src/chapter-4/index.html"
+      path: "/src/chapter-4/index/"
     - id: 5
       title: "ステークホルダーマネジメント"
-      path: "/src/chapter-5/index.html"
+      path: "/src/chapter-5/index/"
     - id: 6
       title: "危機管理と問題解決"
-      path: "/src/chapter-6/index.html"
+      path: "/src/chapter-6/index/"
   
   appendices:
     - id: "A"
       title: "思考ツールテンプレート集"
-      path: "/src/appendices/templates.html"
+      path: "/src/appendices/templates/"
     - id: "B"
       title: "ケーススタディ"
-      path: "/src/appendices/case-studies.html"
+      path: "/src/appendices/case-studies/"
     - id: "C"
       title: "推奨読書リスト"
-      path: "/src/appendices/reading-list.html"
+      path: "/src/appendices/reading-list/"
 


### PR DESCRIPTION
- Replace .html endings in docs/_config.yml structure paths with trailing slash\n- Prevents 404s under permalink: pretty