### PR TITLE
docs: ライセンス表記とMermaidラベルを正規化

### DIFF
--- a/docs/chapters/chapter-01/index.md
+++ b/docs/chapters/chapter-01/index.md
@@ -366,11 +366,11 @@ graph TB
         Level1 --> Level2 --> Level3
         
         subgraph "AI協働のアンチパターン"
-            AntiPattern1[❌ 盲目的依存<br/>・AI出力をそのまま使用<br/>・検証プロセスの欠如<br/>・品質評価の軽視]
+            AntiPattern1[NG 盲目的依存<br/>・AI出力をそのまま使用<br/>・検証プロセスの欠如<br/>・品質評価の軽視]
             
-            AntiPattern2[❌ 曖昧な指示<br/>・期待した結果が得られない<br/>・指示能力の不足<br/>・制約条件の未明示]
+            AntiPattern2[NG 曖昧な指示<br/>・期待した結果が得られない<br/>・指示能力の不足<br/>・制約条件の未明示]
             
-            AntiPattern3[❌ 過度な複雑化<br/>・AI適用範囲の見誤り<br/>・人間判断領域の軽視<br/>・技術的負債の蓄積]
+            AntiPattern3[NG 過度な複雑化<br/>・AI適用範囲の見誤り<br/>・人間判断領域の軽視<br/>・技術的負債の蓄積]
         end
         
         Element4 --> AntiPattern1

--- a/docs/index.md
+++ b/docs/index.md
@@ -122,10 +122,10 @@ permalink: /
 
 ## ライセンス
 
-本書は **Creative Commons BY-NC-SA 4.0** ライセンスで公開されています。  
-**🔓 教育・研究・個人学習での利用は自由** ですが、**💼 商用利用には事前許諾** が必要です。
+本書は **Creative Commons BY-NC-SA 4.0** ライセンスで公開しています。  
+教育・研究・個人学習での利用は自由ですが、商用利用は別途契約（事前許諾）が必要です。
 
-📋 [詳細なライセンス条件](https://github.com/itdojp/it-engineer-knowledge-architecture/blob/main/LICENSE.md)
+[詳細なライセンス条件](https://github.com/itdojp/it-engineer-knowledge-architecture/blob/main/LICENSE.md)
 📌 [ライセンスFAQ](introduction/license-faq/)
 
 **お問い合わせ**  


### PR DESCRIPTION
## 変更内容
- トップページのライセンス表記から装飾絵文字（🔓/💼/📋）を除去し、文言を統一
- Mermaid図内のステータス絵文字（❌）を `NG` ラベルに置換（Mermaidの角括弧構文と衝突しない形式）

## 検証
- node ../book-formatter/scripts/check-unicode.js docs --allowlist .book-formatter/unicode-allowlist.json --fail-on warn
- node ../book-formatter/scripts/check-textlint.js docs --fail-on error
- node ../book-formatter/scripts/check-links.js docs
- node ../book-formatter/scripts/check-layout-risk.js docs --fail-on error
- node ../book-formatter/scripts/check-markdown-structure.js docs --fail-on error
