### PR TITLE
chore: opt GitHub Actions into Node 24 runtime

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [ main ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   qa:
     runs-on: ubuntu-latest
@@ -14,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout book
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout book-formatter (pinned)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: itdojp/book-formatter
           ref: da2a49e7d2dcd9e1fa885e910c458130fe8d73a4
@@ -61,7 +64,7 @@ jobs:
 
       - name: Upload markdown structure report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: markdown-structure-report
           path: ${{ runner.temp }}/markdown-structure-report.json
@@ -69,7 +72,7 @@ jobs:
 
       - name: Upload layout risk report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: layout-risk-report
           path: ${{ runner.temp }}/layout-risk-report.json

--- a/.github/workflows/docs-forbidden-check.yml
+++ b/.github/workflows/docs-forbidden-check.yml
@@ -7,6 +7,9 @@ on:
     branches: ["main"]
   workflow_dispatch: {}
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 permissions:
   contents: read
 
@@ -17,7 +20,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Check forbidden items in docs
         shell: bash
         run: |

--- a/.github/workflows/nav-link-check.yml
+++ b/.github/workflows/nav-link-check.yml
@@ -5,12 +5,15 @@ on:
     - cron: '13 3 * * 1'
   workflow_dispatch: {}
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   nav-link-check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install PyYAML
         run: python3 -m pip install --user pyyaml


### PR DESCRIPTION
## What
- opt this repository into the GitHub-hosted Node 24 runtime for JavaScript actions
- update repo-controlled GitHub Actions majors that currently trigger Node 20 deprecation annotations
- leave `actions/configure-pages@v5` unchanged because it is upstream latest and not repo-controllable here

## Why
- reduce repository-side GitHub Actions deprecation warnings tracked in itdojp/it-engineer-knowledge-architecture#137

## Verification
- `git diff --check`
- `rg "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24|actions/(checkout|cache|upload-artifact|setup-java|upload-pages-artifact)@" .github/workflows -n`

Ref itdojp/it-engineer-knowledge-architecture#137
