### PR TITLE
[codex] Improve AI era engineer top-page guidance

### DIFF
--- a/book-config.json
+++ b/book-config.json
@@ -4,7 +4,7 @@
   "description": "ITエンジニア全般に共通する優れた思考プロセスを体系化し、生成AIを効果的に活用しながら、人間が責任を持って担うべき高度な判断力の向上を目指す実践的ガイド",
   "author": "ITDO Inc.",
   "version": "1.0.0",
-  "license": "CC BY-NC-SA 4.0",
+  "license": "CC-BY-NC-SA-4.0",
   "structure": {
     "introduction": [
       {
@@ -208,12 +208,6 @@
         "title": "推奨読書リスト",
         "path": "/appendices/reading-list/",
         "description": "さらなる学習のための推奨書籍"
-      },
-      {
-        "id": "d",
-        "title": "更新履歴とメンテナンス方針",
-        "path": "/appendices/update-notes/",
-        "description": "更新履歴、版差、メンテナンス方針の確認導線"
       }
     ]
   },
@@ -237,5 +231,6 @@
   "shared": {
     "version": "3.2.2",
     "lastSync": "2026-02-04T23:01:51.889Z"
-  }
+  },
+  "licenseLabel": "CC BY-NC-SA 4.0"
 }

--- a/book-config.json
+++ b/book-config.json
@@ -208,6 +208,12 @@
         "title": "推奨読書リスト",
         "path": "/appendices/reading-list/",
         "description": "さらなる学習のための推奨書籍"
+      },
+      {
+        "id": "d",
+        "title": "更新履歴とメンテナンス方針",
+        "path": "/appendices/update-notes/",
+        "description": "更新履歴、版差、メンテナンス方針の確認導線"
       }
     ]
   },


### PR DESCRIPTION
What changed
- strengthen the public top page with next-step guidance and safety notes
- add usage/update information for reader-facing maintenance tracking
- normalize book-config license metadata to SPDX + label form

Why it changed
- keep the landing page focused on practical next steps for readers
- keep book-config metadata consistent with the recent series-wide convention

Validation
- git diff --check origin/main...HEAD
- cd docs && bundle exec jekyll build
- node /home/devuser/work/CodeX/booksB/repos/book-formatter/scripts/check-links.js .
- node /home/devuser/work/CodeX/booksB/repos/book-formatter/scripts/check-markdown-structure.js . --fail-on error
- jq empty book-config.json
