### PR TITLE
Fix mobile sidebar closed state

### DIFF
--- a/ai-era-engineers-mind-book/docs/assets/css/mobile-responsive.css
+++ b/ai-era-engineers-mind-book/docs/assets/css/mobile-responsive.css
@@ -49,7 +49,14 @@ html {
     border-right: 1px solid var(--border-color);
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
     z-index: 1000;
-    transform: translateX(-100%);
+    /*
+     * main.css imports this file before declaring the default desktop sidebar
+     * transform. Keep the closed drawer state important so the later desktop
+     * `transform: translateX(0)` rule cannot leave the TOC covering content
+     * on mobile and tablet widths. The checked/open rule below is more
+     * specific and also important, so the menu button still opens it.
+     */
+    transform: translateX(-100%) !important;
     transition: transform 0.3s ease;
   }
 

--- a/docs/assets/css/mobile-responsive.css
+++ b/docs/assets/css/mobile-responsive.css
@@ -54,7 +54,14 @@ html {
     border-right: 1px solid var(--border-color);
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
     z-index: 1000;
-    transform: translateX(-100%);
+    /*
+     * main.css imports this file before declaring the default desktop sidebar
+     * transform. Keep the closed drawer state important so the later desktop
+     * `transform: translateX(0)` rule cannot leave the TOC covering content
+     * on mobile and tablet widths. The checked/open rule below is more
+     * specific and also important, so the menu button still opens it.
+     */
+    transform: translateX(-100%) !important;
     transition: transform 0.3s ease;
   }
 


### PR DESCRIPTION
## Summary
- keep the closed mobile/tablet sidebar drawer off-canvas with `!important` so the later desktop `.book-sidebar { transform: translateX(0); }` rule in `main.css` cannot override it
- apply the same fix to both tracked published CSS copies
- leave the checked/open drawer rule unchanged so the hamburger menu still opens the TOC

Context: itdojp/it-engineer-knowledge-architecture#168

## Verification
- `npm ci`
- `npm test`
- `BUNDLE_PATH=/home/devuser/work/CodeX/booksB/.codex-local/tmp/ai-era-mind-bundle-path BUNDLE_APP_CONFIG=/home/devuser/work/CodeX/booksB/.codex-local/tmp/ai-era-mind-bundle-config npm run build`
- `git diff --check`
- local Pages visual check with Chromium: `books=1 pages=10 ok=10 warn=0 fail=0`
- direct Playwright probe over `/` and `/chapters/chapter-01/` at 480/768/820/1024/1280 confirmed the closed drawer is off-canvas on <=1024px, the toggle opens it, and desktop layout remains visible

## Notes
- `npm ci` reports existing dependency audit findings; this PR does not change dependencies.
