### PR TITLE
Fix mobile sidebar visibility guard

### DIFF
--- a/ai-era-engineers-mind-book/docs/assets/css/mobile-responsive.css
+++ b/ai-era-engineers-mind-book/docs/assets/css/mobile-responsive.css
@@ -48,12 +48,6 @@ html {
     background: var(--bg-primary);
     border-right: 1px solid var(--border-color);
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
-    z-index: 999 !important;
-    transform: translateX(-100%) !important;
-    visibility: hidden;
-    transition:
-      transform 0.3s ease,
-      visibility 0s linear 0.3s !important;
     /*
      * main.css imports this file before declaring the default desktop sidebar
      * transform. Keep the closed drawer state important so the later desktop
@@ -61,6 +55,12 @@ html {
      * on mobile and tablet widths. The checked/open rule below is more
      * specific and also important, so the menu button still opens it.
      */
+    z-index: 999 !important;
+    transform: translateX(-100%) !important;
+    visibility: hidden;
+    transition:
+      transform 0.3s ease,
+      visibility 0s linear 0.3s !important;
   }
 
   /* Show sidebar when toggled */

--- a/ai-era-engineers-mind-book/docs/assets/css/mobile-responsive.css
+++ b/ai-era-engineers-mind-book/docs/assets/css/mobile-responsive.css
@@ -48,7 +48,12 @@ html {
     background: var(--bg-primary);
     border-right: 1px solid var(--border-color);
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
-    z-index: 1000;
+    z-index: 999 !important;
+    transform: translateX(-100%) !important;
+    visibility: hidden;
+    transition:
+      transform 0.3s ease,
+      visibility 0s linear 0.3s !important;
     /*
      * main.css imports this file before declaring the default desktop sidebar
      * transform. Keep the closed drawer state important so the later desktop
@@ -56,13 +61,13 @@ html {
      * on mobile and tablet widths. The checked/open rule below is more
      * specific and also important, so the menu button still opens it.
      */
-    transform: translateX(-100%) !important;
-    transition: transform 0.3s ease;
   }
 
   /* Show sidebar when toggled */
   .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar {
     transform: translateX(0) !important;
+    visibility: visible;
+    transition: transform 0.3s ease !important;
   }
   
   /* Ensure sidebar content is interactive */

--- a/docs/assets/css/mobile-responsive.css
+++ b/docs/assets/css/mobile-responsive.css
@@ -53,7 +53,12 @@ html {
     background: var(--bg-primary);
     border-right: 1px solid var(--border-color);
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
-    z-index: 1000;
+    z-index: 999 !important;
+    transform: translateX(-100%) !important;
+    visibility: hidden;
+    transition:
+      transform 0.3s ease,
+      visibility 0s linear 0.3s !important;
     /*
      * main.css imports this file before declaring the default desktop sidebar
      * transform. Keep the closed drawer state important so the later desktop
@@ -61,13 +66,13 @@ html {
      * on mobile and tablet widths. The checked/open rule below is more
      * specific and also important, so the menu button still opens it.
      */
-    transform: translateX(-100%) !important;
-    transition: transform 0.3s ease;
   }
 
   /* Show sidebar when toggled */
   .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar {
     transform: translateX(0) !important;
+    visibility: visible;
+    transition: transform 0.3s ease !important;
   }
   
   /* Ensure sidebar content is interactive */

--- a/docs/assets/css/mobile-responsive.css
+++ b/docs/assets/css/mobile-responsive.css
@@ -53,12 +53,6 @@ html {
     background: var(--bg-primary);
     border-right: 1px solid var(--border-color);
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
-    z-index: 999 !important;
-    transform: translateX(-100%) !important;
-    visibility: hidden;
-    transition:
-      transform 0.3s ease,
-      visibility 0s linear 0.3s !important;
     /*
      * main.css imports this file before declaring the default desktop sidebar
      * transform. Keep the closed drawer state important so the later desktop
@@ -66,6 +60,12 @@ html {
      * on mobile and tablet widths. The checked/open rule below is more
      * specific and also important, so the menu button still opens it.
      */
+    z-index: 999 !important;
+    transform: translateX(-100%) !important;
+    visibility: hidden;
+    transition:
+      transform 0.3s ease,
+      visibility 0s linear 0.3s !important;
   }
 
   /* Show sidebar when toggled */


### PR DESCRIPTION
## Summary
- Reinforce the mobile/tablet sidebar closed state with `visibility: hidden` and a delayed visibility transition.
- Keep the opened sidebar visible and above the overlay while preserving the existing off-canvas transform fix.
- Apply the same guard to each tracked `mobile-responsive.css` copy in this repository to avoid asset drift.

Part of itdojp/it-engineer-knowledge-architecture#168.

## Verification
- `git diff --check`
- Static CSS guard check for `z-index: 999 !important`, closed `transform: translateX(-100%) !important`, closed `visibility: hidden`, delayed visibility transition, and opened `visibility: visible`.
